### PR TITLE
18.0 Update 8 (Build 912) with Dot Net 6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,27 +9,27 @@ Sometimes i get a bug Mail, but no respone who is using it.
 
 ------------
 
-#### Supportet by 18.0 (Build 912)
+### Supportet by 18.0 (Build 912)
 
 ------------
 
 
-#### Requirements
+### Requirements
 - Dot Net 6.0
 - 3CXPhoneSystem.ini (Debian User must fix the Path in the ini for the 3cxpscomcpp2.dll ->  instanceBinPath = /usr/lib/3cxpbx)
 
 ------------
 
 
-#### Installation
+### Installation
 
-##### Windows
+#### Windows
 
 - Download from Microsoft Dot Net 5.0
 - Install Dot Net Core
 - run in cmd dotnet build WebAPICore.csproj
 
-##### Linux (Debian 10)
+#### Linux (Debian 10/11)
 
 ```bash
 wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
@@ -37,7 +37,7 @@ sudo dpkg -i packages-microsoft-prod.deb
 sudo apt-get update; sudo apt-get install -y apt-transport-https && sudo apt-get update && sudo apt-get install -y dotnet-sdk-6.0
 ```
 
-**Bevore compile, you need to edit the **  *WebAPICore.csproj*
+**Bevore compile, you need to edit the**  *WebAPICore.csproj*
 - remove *`<Private>false</Private>`* in <ItemGroup> for 3cxpscomcpp2
 - edit path: `<HintPath>..\..\..\Program Files\3CX Phone System\Bin\3cxpscomcpp2.dll</HintPath>` to `<HintPath>/usr/lib/3cxpbx/3cxpscomcpp2.dll</HintPath>` 
 
@@ -46,7 +46,7 @@ cd ./bin/Debug/net6.0
 cp -pr /var/lib/3cxpbx/Bin/3CXPhoneSystem.ini .
 ```
 
-**Edit **  *3CXPhoneSystem.ini*
+**Edit**  *3CXPhoneSystem.ini*
 - add *`instanceBinPath = /usr/lib/3cxpbx`* before *`[ConfService]`* in the copy of *3CXPhoneSystem.ini*
 
 ```bash
@@ -54,7 +54,7 @@ dotnet build WebAPICore.csproj
 ```
 
 
-#### Start the API
+### Start the API
 Now you can start the API.
 it is in this path: bin\Debug\net6.0
 You need the 3CXPhoneSystem.ini in your API folder
@@ -69,7 +69,7 @@ Sample: dotnet WebAPICore.dll 8888
 
 Sample debug mode: dotnet WebAPICore.dll 8888 debug
 
-##### Features
+#### Features
 URL: http://ip:port/action/arg1/arg2/.....
 
 **Action:**

--- a/README.md
+++ b/README.md
@@ -46,6 +46,9 @@ cd ./bin/Debug/net6.0
 cp -pr /var/lib/3cxpbx/Bin/3CXPhoneSystem.ini .
 ```
 
+**Edit **  *3CXPhoneSystem.ini*
+- add *`instanceBinPath = /usr/lib/3cxpbx`* before *`[ConfService]`* in the copy of *3CXPhoneSystem.ini*
+
 ```bash
 dotnet build WebAPICore.csproj
 ```

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@ Sometimes i get a bug Mail, but no respone who is using it.
 
 ------------
 
-#### Supportet by v18 Alpha4
+#### Supportet by 18.0 (Build 912)
 
 ------------
 
 
 #### Requirements
-- Dot Net 5.0
-- 3CXPhoneSystem.ini (Debian User must fix the Path in the ini for the 3cxpscomcpp2.dll)
+- Dot Net 6.0
+- 3CXPhoneSystem.ini (Debian User must fix the Path in the ini for the 3cxpscomcpp2.dll ->  instanceBinPath = /usr/lib/3cxpbx)
 
 ------------
 
@@ -34,13 +34,17 @@ Sometimes i get a bug Mail, but no respone who is using it.
 ```bash
 wget https://packages.microsoft.com/config/debian/10/packages-microsoft-prod.deb -O packages-microsoft-prod.deb
 sudo dpkg -i packages-microsoft-prod.deb
-sudo apt-get update; \ sudo apt-get install -y apt-transport-https && \ sudo apt-get update && \ sudo apt-get install -y dotnet-sdk-5.0
+sudo apt-get update; sudo apt-get install -y apt-transport-https && sudo apt-get update && sudo apt-get install -y dotnet-sdk-6.0
 ```
 
 **Bevore compile, you need to edit the **  *WebAPICore.csproj*
 - remove *`<Private>false</Private>`* in <ItemGroup> for 3cxpscomcpp2
 - edit path: `<HintPath>..\..\..\Program Files\3CX Phone System\Bin\3cxpscomcpp2.dll</HintPath>` to `<HintPath>/usr/lib/3cxpbx/3cxpscomcpp2.dll</HintPath>` 
 
+```bash
+cd ./bin/Debug/net6.0
+cp -pr /var/lib/3cxpbx/Bin/3CXPhoneSystem.ini .
+```
 
 ```bash
 dotnet build WebAPICore.csproj
@@ -49,7 +53,7 @@ dotnet build WebAPICore.csproj
 
 #### Start the API
 Now you can start the API.
-it is in this path: bin\Debug\net5.0
+it is in this path: bin\Debug\net6.0
 You need the 3CXPhoneSystem.ini in your API folder
 
 **For Windows User, the API need Admin rights, so start cmd as Administrator.**

--- a/WebAPICore.csproj
+++ b/WebAPICore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <ApplicationIcon />
     <StartupObject>WebAPI.Program</StartupObject>
     <RootNamespace>WebAPI</RootNamespace>

--- a/update.cs
+++ b/update.cs
@@ -32,6 +32,7 @@ namespace WebAPI
             catch (Exception ex)
             {
                 Console.WriteLine($"Update failed\n{ex}");
+                return null;
             }
         }
     }


### PR DESCRIPTION
Got to run the web-API on my tesing environment with 18.0 Update 8 (Build 912)  and Dot Net 6.0. Also included some small changes for the Linux Version to make it work there